### PR TITLE
いいねのみにし、お気に入りの情報を削除

### DIFF
--- a/src/app/components/commonComponents/illustration/illustrations.tsx
+++ b/src/app/components/commonComponents/illustration/illustrations.tsx
@@ -191,20 +191,12 @@ const ImageDetail = () => {
               </p>
             </div>
 
-            {/* いいねとお気に入り */}
+            {/* いいね */}
             <div className="flex items-center space-x-1 p-5">
-              {/* いいね */}
               <div className="text-center">
                 <p className="text-sm text-gray-500 mb-1">いいね</p>
                 <span className="text-5xl text-red-500 rounded-lg cursor-pointer">
                   ♡
-                </span>
-              </div>
-              {/* お気に入り */}
-              <div className="text-center">
-                <p className="text-sm text-gray-500 mb-1">お気に入り</p>
-                <span className="text-5xl text-yellow-300 rounded-lg cursor-pointer">
-                  ☆
                 </span>
               </div>
             </div>

--- a/src/app/components/myComponents/Stats.tsx
+++ b/src/app/components/myComponents/Stats.tsx
@@ -48,11 +48,6 @@ export default async function Stats() {
           〇〇回
         </p>
         <p className="text-xl">
-          ⭐︎ お気に入り
-          <br />
-          〇〇回
-        </p>
-        <p className="text-xl">
           ✍️ コメント
           <br />
           {count}回


### PR DESCRIPTION
## なぜ削除するのか
・個人開発において開発リソースが大きすぎた
・そこまで実装する余力がない
・いいねとお気に入りを両立させる意味があまりないように感じた
・第三者に意見をもらったが、他のサービスと比較してお気に入りを実装する必要があるのかわからないという意見を貰った

・まだいいねおよびお気に入りの開発はしていないので今が引き返し時だと思った