### PR TITLE
レスポンシブでレイアウト崩れを修正

### DIFF
--- a/src/app/components/commonComponents/container/paddingCotainer.tsx
+++ b/src/app/components/commonComponents/container/paddingCotainer.tsx
@@ -6,7 +6,7 @@ interface PaddingContainerProps {
 
 const PaddingContainer: React.FC<PaddingContainerProps> = ({ children }) => {
   return (
-    <div className='sm:p-10'>
+    <div className='sm:p-10 flex flex-col w-full'>
       {children}
     </div>
   );

--- a/src/app/components/commonComponents/navigation/seachBar.tsx
+++ b/src/app/components/commonComponents/navigation/seachBar.tsx
@@ -16,8 +16,8 @@ export default function SearchBar({ initialValue }: { initialValue: string }) {
   };
 
   return (
-    <form className="flex-grow max-w-2xl mx-2" onSubmit={handleSearch}>
-      <div className="relative w-full">
+    <form className="flex-grow max-w-2xl mx-2 w-full m-4 sm:m-0" onSubmit={handleSearch}>
+      <div className="relative">
         <FontAwesomeIcon
           icon={faMagnifyingGlass}
           className="absolute top-1/2 left-3 transform -translate-y-1/2 text-gray-400"

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -49,7 +49,9 @@ export default function SearchResult() {
 
   return (
     <PaddingContainer>
-      <SearchBar initialValue={search || ""} />
+      <div className="flex justify-center">
+        <SearchBar initialValue={search || ""} />
+      </div>
       {imageData.length === 0 && <Loading />}
       <GridContainer>
         {imageData &&


### PR DESCRIPTION
## 修正点
・Container関連のレスポンシブを簡単に修正
・検索がsearchページで左によっていたため修正